### PR TITLE
Makefile: fix compile problem if use system default opencv4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ appname := Heartbeat
 
 CXX := g++
 RM := rm -f
-CXXFLAGS := -Wall -g -std=c++11 -I/usr/local/include/opencv4
+CXXFLAGS := -Wall -g -std=c++11 -I/usr/local/include/opencv4 -I/usr/include/opencv4
 LDFLAGS := -g
 LDLIBS := -lopencv_core -lopencv_dnn -lopencv_highgui -lopencv_imgcodecs -lopencv_imgproc -lopencv_objdetect -lopencv_video -lopencv_videoio
 


### PR DESCRIPTION
Some linux distro installed opencv to /usr/include/opencv4 by default
So add -I/usr/include/opencv4 as include PATH to make sure it could
build.